### PR TITLE
Fix ODPT proxy base URL and e-ink station fallback

### DIFF
--- a/scripts/cloudflare/worker.js
+++ b/scripts/cloudflare/worker.js
@@ -22,7 +22,7 @@
 
 // Configuration constants
 const DEFAULT_CACHE_TTL = 3600; // 1 hour
-const DEFAULT_API_BASE_URL = 'https://api-challenge.odpt.org/api/v4/';
+const DEFAULT_API_BASE_URL = 'https://api.odpt.org/api/v4/';
 const MCP_EXAMPLE_URL =
   '/mcp/resources/get?uri=odpt://Station&odpt:railway=odpt.Railway:Tokyu.Toyoko';
 

--- a/scripts/rpi-eink/render-to-image.ts
+++ b/scripts/rpi-eink/render-to-image.ts
@@ -27,6 +27,7 @@ import {
 
 import {
   fetchRailwayByUri,
+  fetchStationsList,
   fetchStationTimetable,
   fetchStationsByUris,
   calendarURI,
@@ -545,8 +546,18 @@ async function renderToImage(
   const inboundDirUri = railway['odpt:ascendingRailDirection'];
   const outboundDirUri = railway['odpt:descendingRailDirection'];
 
-  // Find station in stationOrder
-  const stationOrder = railway['odpt:stationOrder'] || [];
+  // Find station in stationOrder.
+  // ODPT v4 may return an empty stationOrder, so fall back to Station list by railway.
+  let stationOrder = railway['odpt:stationOrder'] || [];
+  if (stationOrder.length === 0) {
+    const stations = await fetchStationsList(apiKey, apiBaseUrl, railwayUri);
+    stationOrder = stations.map((s) => ({
+      'odpt:station': s['owl:sameAs'] || s['@id'] || '',
+      'odpt:stationTitle': s['dc:title'] || s['odpt:stationTitle'] || '',
+    })) as any[];
+    console.log(`[STATION] stationOrder missing in Railway response, using ${stationOrder.length} stations from Station list`);
+  }
+
   let stationUri: string | null = null;
   for (const station of stationOrder) {
     const sName = getJapaneseText(station['odpt:stationTitle']);


### PR DESCRIPTION
## Summary
- switch the Cloudflare worker default ODPT base URL from `api-challenge.odpt.org` to `api.odpt.org`
- add a fallback in `render-to-image.ts` to resolve stations from `odpt:Station` when `odpt:stationOrder` is empty in `odpt:Railway`
- unblock Raspberry Pi `trainboard-display.service` updates by preventing station matching failures for Toyoko/Naka-Meguro

## Test plan
- [x] `npm run -s typecheck`
- [x] call proxy endpoint and verify `200` response from `https://odpt-api-proxy.trainboard-odpt-proxy.workers.dev`
- [x] run `sudo systemctl start trainboard-display.service` on RPi and verify `status=0/SUCCESS`
- [x] confirm service log shows `Direct rendering completed successfully` and `Display update completed successfully!`

Made with [Cursor](https://cursor.com)